### PR TITLE
feat: add base_url configuration support for LLM providers

### DIFF
--- a/windows_use/cli/__main__.py
+++ b/windows_use/cli/__main__.py
@@ -195,11 +195,15 @@ def _run_interactive(provider: str, model: str, max_steps: int, debug: bool = Fa
     """Run the interactive task loop."""
     from windows_use.cli.setup import create_llm, run_llm_switch, run_speech_setup
     from windows_use.cli.setup import create_stt_provider, create_tts_provider
+    from windows_use.cli.config import get_active_config
     from windows_use.agent import Agent, Browser
     from windows_use.cli.subscriber import CLIEventSubscriber
 
     agent = None
-    llm = create_llm(provider, model)
+    # Get base_url from config if available
+    active_config = get_active_config()
+    base_url = active_config.get("base_url") if active_config else None
+    llm = create_llm(provider, model, base_url=base_url)
     provider_display = get_provider_display(provider)
 
     # Resolve STT/TTS (lazy - may fail if pyaudio not installed)
@@ -290,7 +294,9 @@ def _run_interactive(provider: str, model: str, max_steps: int, debug: bool = Fa
             try:
                 from windows_use.cli.setup import run_key_change
                 if run_key_change():
-                    llm = create_llm(provider, model)
+                    active_config = get_active_config()
+                    base_url = active_config.get("base_url") if active_config else None
+                    llm = create_llm(provider, model, base_url=base_url)
                     agent = Agent(
                         llm=llm,
                         browser=Browser.EDGE,
@@ -408,7 +414,9 @@ def _run_interactive(provider: str, model: str, max_steps: int, debug: bool = Fa
             if result is None:
                 continue
             provider, model = result
-            llm = create_llm(provider, model)
+            active_config = get_active_config()
+            base_url = active_config.get("base_url") if active_config else None
+            llm = create_llm(provider, model, base_url=base_url)
             provider_display = get_provider_display(provider)
 
             agent = Agent(

--- a/windows_use/cli/config.py
+++ b/windows_use/cli/config.py
@@ -67,13 +67,16 @@ def get_providers_config() -> list[dict[str, Any]]:
 
 
 def get_active_config() -> dict[str, Any] | None:
-    """Return the active provider config (provider, llm, api_key decrypted) or None."""
+    """Return the active provider config (provider, llm, api_key decrypted, base_url) or None."""
     configs = get_providers_config()
     for c in configs:
         if c.get("active") is True:
             out = dict(c)
             enc = out.pop("api_key_encrypted", "")
             out["api_key"] = decrypt_secret(enc) if enc else None
+            # Include base_url if present
+            if "base_url" not in out:
+                out["base_url"] = None
             return out
     return None
 
@@ -110,6 +113,7 @@ def upsert_provider(
     provider: str,
     llm: str,
     api_key: str | None = None,
+    base_url: str | None = None,
     set_active: bool = True,
 ) -> None:
     """Add or update a provider config. If set_active, deactivates others."""
@@ -120,17 +124,22 @@ def upsert_provider(
             c["llm"] = llm
             if api_key is not None:
                 c["api_key_encrypted"] = encrypt_secret(api_key) if api_key else ""
+            if base_url is not None:
+                c["base_url"] = base_url
             if set_active:
                 c["active"] = True
             updated = True
             break
     if not updated:
-        configs.append({
+        new_config = {
             "provider": provider,
             "llm": llm,
             "api_key_encrypted": encrypt_secret(api_key) if api_key else "",
             "active": set_active,
-        })
+        }
+        if base_url is not None:
+            new_config["base_url"] = base_url
+        configs.append(new_config)
     if set_active:
         for c in configs:
             if c.get("provider") != provider:
@@ -144,6 +153,17 @@ def update_provider_api_key(provider: str, api_key: str) -> None:
     for c in configs:
         if c.get("provider") == provider:
             c["api_key_encrypted"] = encrypt_secret(api_key) if api_key else ""
+            save_providers_config(configs)
+            return
+    raise ValueError(f"Provider '{provider}' not found in config")
+
+
+def update_provider_base_url(provider: str, base_url: str) -> None:
+    """Update the base URL for an existing provider config."""
+    configs = get_providers_config()
+    for c in configs:
+        if c.get("provider") == provider:
+            c["base_url"] = base_url if base_url else None
             save_providers_config(configs)
             return
     raise ValueError(f"Provider '{provider}' not found in config")

--- a/windows_use/cli/setup.py
+++ b/windows_use/cli/setup.py
@@ -18,6 +18,7 @@ from windows_use.cli.config import (
     get_speech_config,
     save_speech_config,
     update_provider_api_key,
+    update_provider_base_url,
     upsert_provider,
 )
 from windows_use.cli.registry import get_provider_display, get_providers, get_models, provider_requires_api_key
@@ -105,7 +106,21 @@ def run_setup() -> dict[str, str]:
             raise KeyboardInterrupt("Setup cancelled")
         api_key = api_key.strip()
 
-    upsert_provider(provider_key, model_id, api_key=api_key, set_active=True)
+    # Ask for base URL (optional)
+    base_url: str | None = None
+    set_base_url = questionary.confirm(
+        "Do you want to set a custom base URL? (optional)",
+        default=False,
+        style=_SELECT_STYLE,
+    ).ask()
+    if set_base_url:
+        base_url = questionary.text(
+            "Enter base URL:",
+        ).ask()
+        if base_url:
+            base_url = base_url.strip()
+
+    upsert_provider(provider_key, model_id, api_key=api_key, base_url=base_url, set_active=True)
 
     console.print("[dim]Creating .windows-use...[/]")
 
@@ -173,8 +188,22 @@ def run_llm_switch() -> tuple[str, str] | None:
                 return None
             api_key = api_key.strip()
 
+    # Ask for base URL (optional)
+    base_url: str | None = None
+    set_base_url = questionary.confirm(
+        "Do you want to set a custom base URL? (optional)",
+        default=False,
+        style=_SELECT_STYLE,
+    ).ask()
+    if set_base_url:
+        base_url = questionary.text(
+            "Enter base URL:",
+        ).ask()
+        if base_url:
+            base_url = base_url.strip()
+
     # Only update config once we have all required input (provider, model, api_key if needed)
-    upsert_provider(provider_key, model_id, api_key=api_key, set_active=True)
+    upsert_provider(provider_key, model_id, api_key=api_key, base_url=base_url, set_active=True)
 
     return provider_key, model_id
 
@@ -212,13 +241,84 @@ def run_key_change() -> bool:
         return False
 
     update_provider_api_key(provider_key, api_key.strip())
+
+    # Ask if user wants to set base URL
+    set_base_url = questionary.confirm(
+        "Do you want to set a custom base URL?",
+        default=False,
+        style=_SELECT_STYLE,
+    ).ask()
+
+    if set_base_url:
+        # Get current base_url if exists
+        current_base_url = None
+        for c in configs:
+            if c.get("provider") == provider_key:
+                current_base_url = c.get("base_url")
+                break
+
+        default_text = current_base_url if current_base_url else ""
+
+        base_url = questionary.text(
+            "Enter base URL (leave empty to use default):",
+            default=default_text,
+        ).ask()
+
+        if base_url is not None:
+            update_provider_base_url(provider_key, base_url.strip())
+
     return True
 
 
-def create_llm(provider: str, model: str, api_key: str | None = None):
+def run_base_url_change() -> bool:
+    """Interactive prompt to change base URL for a configured provider. Returns True if updated."""
+    import questionary
+
+    configs = get_providers_config()
+    providers_list = [
+        (get_provider_display(c["provider"]), c["provider"])
+        for c in configs
+    ]
+    if not providers_list:
+        return False
+
+    provider_choice = questionary.select(
+        "Which provider's base URL to change?",
+        choices=[name for name, _ in providers_list],
+        style=_SELECT_STYLE,
+    ).ask()
+
+    if provider_choice is None:
+        return False
+
+    provider_key = next(k for n, k in providers_list if n == provider_choice)
+
+    # Get current base_url if exists
+    current_base_url = None
+    for c in configs:
+        if c.get("provider") == provider_key:
+            current_base_url = c.get("base_url")
+            break
+
+    default_text = current_base_url if current_base_url else ""
+
+    base_url = questionary.text(
+        "Enter new base URL (leave empty to use default):",
+        default=default_text,
+    ).ask()
+
+    if base_url is None:
+        return False
+
+    update_provider_base_url(provider_key, base_url.strip())
+    return True
+
+
+def create_llm(provider: str, model: str, api_key: str | None = None, base_url: str | None = None):
     """Create LLM instance from provider key and model id.
 
     api_key: From config (decrypted) or env. Passed explicitly overrides env.
+    base_url: From config or env. Passed explicitly overrides env.
     """
     # Resolve API key: explicit arg > config > env
     key = api_key
@@ -229,40 +329,40 @@ def create_llm(provider: str, model: str, api_key: str | None = None):
 
     if provider == "groq":
         from windows_use.providers.groq import ChatGroq
-        return ChatGroq(model=model, api_key=key)
+        return ChatGroq(model=model, api_key=key, base_url=base_url)
     if provider == "openai":
         from windows_use.providers.openai import ChatOpenAI
-        return ChatOpenAI(model=model, api_key=key)
+        return ChatOpenAI(model=model, api_key=key, base_url=base_url)
     if provider == "anthropic":
         from windows_use.providers.anthropic import ChatAnthropic
-        return ChatAnthropic(model=model, api_key=key)
+        return ChatAnthropic(model=model, api_key=key, base_url=base_url)
     if provider == "google":
         from windows_use.providers.google import ChatGoogle
-        return ChatGoogle(model=model, api_key=key)
+        return ChatGoogle(model=model, api_key=key, base_url=base_url)
     if provider == "ollama":
         from windows_use.providers.ollama import ChatOllama
-        return ChatOllama(model=model)
+        return ChatOllama(model=model, host=base_url)
     if provider == "mistral":
         from windows_use.providers.mistral import ChatMistral
-        return ChatMistral(model=model, api_key=key)
+        return ChatMistral(model=model, api_key=key, base_url=base_url)
     if provider == "cerebras":
         from windows_use.providers.cerebras import ChatCerebras
-        return ChatCerebras(model=model, api_key=key)
+        return ChatCerebras(model=model, api_key=key, base_url=base_url)
     if provider == "open_router":
         from windows_use.providers.open_router import ChatOpenRouter
-        return ChatOpenRouter(model=model, api_key=key)
+        return ChatOpenRouter(model=model, api_key=key, base_url=base_url)
     if provider == "azure_openai":
         from windows_use.providers.azure_openai import ChatAzureOpenAI
         return ChatAzureOpenAI(deployment_name=model, api_key=key)
     if provider == "litellm":
         from windows_use.providers.litellm import ChatLiteLLM
-        return ChatLiteLLM(model=model, api_key=key)
+        return ChatLiteLLM(model=model, api_key=key, base_url=base_url)
     if provider == "deepseek":
         from windows_use.providers.deepseek import ChatDeepSeek
-        return ChatDeepSeek(model=model, api_key=key)
+        return ChatDeepSeek(model=model, api_key=key, base_url=base_url)
     if provider == "nvidia":
         from windows_use.providers.nvidia import ChatNvidia
-        return ChatNvidia(model=model, api_key=key)
+        return ChatNvidia(model=model, api_key=key, base_url=base_url)
     raise ValueError(f"Unknown provider: {provider}")
 
 

--- a/windows_use/providers/google/llm.py
+++ b/windows_use/providers/google/llm.py
@@ -32,6 +32,7 @@ class ChatGoogle(BaseChatLLM):
         self,
         model: str = "gemini-2.5-flash",
         api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
         temperature: Optional[float] = None,
         thinking_budget: Optional[int] = None,
         **kwargs,
@@ -42,16 +43,22 @@ class ChatGoogle(BaseChatLLM):
         Args:
             model: The model name to use. Defaults to "gemini-2.5-flash".
             api_key: Google API key. Falls back to GEMINI_API_KEY or GOOGLE_API_KEY env vars.
+            base_url: Base URL for the API. Defaults to GOOGLE_BASE_URL environment variable.
             temperature: Sampling temperature.
             thinking_budget: Token budget for extended thinking (Gemini 2.5 models).
             **kwargs: Additional arguments for GenerateContentConfig.
         """
         self._model = model
         self.api_key = api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        self.base_url = base_url or os.environ.get("GOOGLE_BASE_URL")
         self.temperature = temperature
         self.thinking_budget = thinking_budget
 
-        self.client = genai.Client(api_key=self.api_key)
+        client_kwargs = {"api_key": self.api_key}
+        if self.base_url:
+            client_kwargs["http_options"] = {"api_endpoint": self.base_url}
+
+        self.client = genai.Client(**client_kwargs)
         self.kwargs = kwargs
 
     @property


### PR DESCRIPTION
This commit adds comprehensive base_url support across the project:

- Add base_url parameter to Google Gemini provider
- Extend config system to store and retrieve base_url
- Integrate base_url configuration into CLI setup flow
- Update \key command to optionally configure base_url
- Update \llm command to optionally configure base_url
- Pass base_url from config to LLM instances

Benefits:
- Users can now use custom API endpoints or proxies
- Supports self-hosted LLM deployments
- Compatible with API gateway services
- Can be configured via CLI, code, or environment variables

Configuration methods:
1. Via CLI: \key or \llm commands will prompt for base_url
2. Via code: Pass base_url parameter to provider constructors
3. Via env: Set provider-specific env vars (e.g., OPENAI_BASE_URL)
4. Via config: Stored in ~/.windows-use/config.json

Supported providers:
OpenAI, Anthropic, Google Gemini, DeepSeek, Groq, Mistral, Cerebras, OpenRouter, LiteLLM, NVIDIA, vLLM

Note: Ollama uses 'host' parameter, Azure OpenAI uses 'azure_endpoint'